### PR TITLE
only automatically start sshd on the host if debug flag is set

### DIFF
--- a/config/etc/zero-os/conf/openssh.toml
+++ b/config/etc/zero-os/conf/openssh.toml
@@ -1,5 +1,6 @@
 [startup.sshdkeys]
 name = "bash"
+condition = "debug"
 after = ["init"]
 running_delay = -1
 
@@ -13,6 +14,7 @@ ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -N '' -t ed25519
 
 [startup.sshd]
 name = "core.system"
+condition = "debug"
 after = ["sshdkeys"]
 
 [startup.sshd.args]


### PR DESCRIPTION
not sure why this is still there by default but I think it's time we only enable this when debug flag is set