### PR TITLE
autobuild: update github actions to use container ubuntu 18.04

### DIFF
--- a/.github/workflows/kernel.yaml
+++ b/.github/workflows/kernel.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: "Install: requirements"
         run: |
-          sudo bash ./autobuild/tf-build-deps-clean.sh
+          bash ./autobuild/tf-build-deps-clean.sh
  
       - name: "Install: rust"
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/kernel.yaml
+++ b/.github/workflows/kernel.yaml
@@ -9,7 +9,8 @@ on:
 jobs:
   kernel:
     name: "Zero-OS Kernel Image"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v1

--- a/.github/workflows/kernel.yaml
+++ b/.github/workflows/kernel.yaml
@@ -40,27 +40,27 @@ jobs:
       - name: "Fetch: sources"
         run: |
           export INTERACTIVE="false"
-          sudo --preserve-env=PATH bash initramfs.sh --download
+          bash initramfs.sh --download
 
       - name: "Build: busybox"
         run: |
-          sudo --preserve-env=PATH bash initramfs.sh --busybox
+          bash initramfs.sh --busybox
 
       - name: "Build: userland"
         run: |
-          sudo --preserve-env=PATH bash initramfs.sh --tools
+          bash initramfs.sh --tools
 
       - name: "Build: extensions"
         run: |
-          sudo --preserve-env=PATH bash initramfs.sh --extensions
+          bash initramfs.sh --extensions
 
       - name: "Build: cores"
         run: |
-          sudo --preserve-env=PATH bash initramfs.sh --cores
+          bash initramfs.sh --cores
 
       - name: "Build: kernel"
         run: |
-          sudo --preserve-env=PATH bash initramfs.sh --kernel --modules
+          bash initramfs.sh --kernel --modules
 
       - name: "Upload: kernel"
         env:

--- a/.github/workflows/kernel.yaml
+++ b/.github/workflows/kernel.yaml
@@ -26,16 +26,16 @@ jobs:
           go-version: 1.14
         id: go
 
+      - name: "Install: requirements"
+        run: |
+          sudo bash ./autobuild/tf-build-deps-clean.sh
+ 
       - name: "Install: rust"
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: x86_64-unknown-linux-musl
           default: true
-
-      - name: "Install: requirements"
-        run: |
-          sudo bash ./autobuild/tf-build-deps-clean.sh
 
       - name: "Fetch: sources"
         run: |

--- a/autobuild/tf-build-deps-clean.sh
+++ b/autobuild/tf-build-deps-clean.sh
@@ -3,7 +3,7 @@
 apt-get update
 
 # ubuntu image hotfix
-apt-get install wget
+apt-get -y install wget
 
 wget http://archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev1_237-3ubuntu10_amd64.deb
 wget http://archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_237-3ubuntu10_amd64.deb

--- a/autobuild/tf-build-deps-clean.sh
+++ b/autobuild/tf-build-deps-clean.sh
@@ -5,11 +5,11 @@ apt-get update
 # ubuntu image hotfix
 apt-get -y install wget
 
-wget http://archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev1_237-3ubuntu10_amd64.deb
-wget http://archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_237-3ubuntu10_amd64.deb
-dpkg -i libudev1_237-3ubuntu10_amd64.deb
-dpkg -i libudev-dev_237-3ubuntu10_amd64.deb
-rm -f *deb
+# wget http://archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev1_237-3ubuntu10_amd64.deb
+# wget http://archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_237-3ubuntu10_amd64.deb
+# dpkg -i libudev1_237-3ubuntu10_amd64.deb
+# dpkg -i libudev-dev_237-3ubuntu10_amd64.deb
+# rm -f *deb
 
 # install dependencies for building
 apt-get install -y asciidoc xmlto --no-install-recommends

--- a/autobuild/tf-build-deps-clean.sh
+++ b/autobuild/tf-build-deps-clean.sh
@@ -2,15 +2,6 @@
 
 apt-get update
 
-# ubuntu image hotfix
-apt-get -y install wget
-
-# wget http://archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev1_237-3ubuntu10_amd64.deb
-# wget http://archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_237-3ubuntu10_amd64.deb
-# dpkg -i libudev1_237-3ubuntu10_amd64.deb
-# dpkg -i libudev-dev_237-3ubuntu10_amd64.deb
-# rm -f *deb
-
 # install dependencies for building
 apt-get install -y asciidoc xmlto --no-install-recommends
 

--- a/autobuild/tf-build-deps-clean.sh
+++ b/autobuild/tf-build-deps-clean.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
-# install dependencies for building
 apt-get update
+
+# ubuntu image hotfix
+apt-get install wget
+
+wget http://archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev1_237-3ubuntu10_amd64.deb
+wget http://archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_237-3ubuntu10_amd64.deb
+dpkg -i libudev1_237-3ubuntu10_amd64.deb
+dpkg -i libudev-dev_237-3ubuntu10_amd64.deb
+rm -f *deb
+
+# install dependencies for building
 apt-get install -y asciidoc xmlto --no-install-recommends
 
 # toolchain dependencies


### PR DESCRIPTION
This update workflow to force usage of Ubuntu 18.04 container, to avoid any problem when GitHub will drop support of 18.04 officially.

This fixes #56 