### PR TITLE
Fix package download URLs after repo renames (zinit->zos_zinit, rfs->zos_rfs)

### DIFF
--- a/packages/0-fs.sh
+++ b/packages/0-fs.sh
@@ -1,6 +1,6 @@
 ZFS_VERSION="1.1.1"
 ZFS_HASH="974b8dc45ae9c1b00238a79b0f4fc9de"
-ZFS_BINARY="https://github.com/threefoldtech/rfs/releases/download/v${ZFS_VERSION}/rfs"
+ZFS_BINARY="https://github.com/threefoldtech/zos_rfs/releases/download/v${ZFS_VERSION}/rfs"
 
 download_zfs() {
     download_file ${ZFS_BINARY} ${ZFS_HASH} "rfs-${ZFS_VERSION}"

--- a/packages/zinit.sh
+++ b/packages/zinit.sh
@@ -1,6 +1,6 @@
 ZINIT_VERSION="0.2.11"
 ZINIT_HASH="e1d6a6f0ff604e58735cd7bd127e5c78"
-ZINIT_BINARY="https://github.com/threefoldtech/zinit/releases/download/v${ZINIT_VERSION}/zinit"
+ZINIT_BINARY="https://github.com/threefoldtech/zos_zinit/releases/download/v${ZINIT_VERSION}/zinit"
 
 download_zinit() {
     download_file ${ZINIT_BINARY} ${ZINIT_HASH} "zinit-${ZINIT_VERSION}"


### PR DESCRIPTION
Points the zinit and rfs release-asset download URLs at their new repo names (`zos_zinit`, `zos_rfs`) instead of relying on GitHub's non-permanent rename redirects.

- `packages/zinit.sh`: `threefoldtech/zinit` -> `threefoldtech/zos_zinit`
- `packages/0-fs.sh`: `threefoldtech/rfs` -> `threefoldtech/zos_rfs`

Verified both new-name asset URLs return 200. No functional change.

Part of the repo-rename migration off GitHub redirects.