### PR TITLE
Revert zinit/rfs URL rename (v4)

### DIFF
--- a/packages/0-fs.sh
+++ b/packages/0-fs.sh
@@ -1,6 +1,6 @@
 ZFS_VERSION="1.1.1"
 ZFS_HASH="974b8dc45ae9c1b00238a79b0f4fc9de"
-ZFS_BINARY="https://github.com/threefoldtech/zos_rfs/releases/download/v${ZFS_VERSION}/rfs"
+ZFS_BINARY="https://github.com/threefoldtech/rfs/releases/download/v${ZFS_VERSION}/rfs"
 
 download_zfs() {
     download_file ${ZFS_BINARY} ${ZFS_HASH} "rfs-${ZFS_VERSION}"

--- a/packages/zinit.sh
+++ b/packages/zinit.sh
@@ -1,6 +1,6 @@
 ZINIT_VERSION="0.2.11"
 ZINIT_HASH="e1d6a6f0ff604e58735cd7bd127e5c78"
-ZINIT_BINARY="https://github.com/threefoldtech/zos_zinit/releases/download/v${ZINIT_VERSION}/zinit"
+ZINIT_BINARY="https://github.com/threefoldtech/zinit/releases/download/v${ZINIT_VERSION}/zinit"
 
 download_zinit() {
     download_file ${ZINIT_BINARY} ${ZINIT_HASH} "zinit-${ZINIT_VERSION}"


### PR DESCRIPTION
The zinit and rfs repos were renamed back to their original names. Revert the earlier repo-rename URL change: threefoldtech/zos_zinit -> threefoldtech/zinit and threefoldtech/zos_rfs -> threefoldtech/rfs. Restores the original package download URLs.